### PR TITLE
Fixes for 'premature close' issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-myq2",
-  "version": "1.2.23 beta-1",
+  "version": "1.2.23",
   "displayName": "Homebridge MyQ",
   "description": "MyQ LiftMaster and Chamberlain plugin for Homebridge",
   "repository": {


### PR DESCRIPTION
`0 info it worked if it ends with ok
1 verbose cli [
1 verbose cli   '/usr/local/Cellar/node/14.4.0/bin/node',
1 verbose cli   '/usr/local/bin/npm',
1 verbose cli   'install',
1 verbose cli   '-g',
1 verbose cli   'DMBlakeley/homebridge-myq2'
1 verbose cli ]
2 info using npm@6.14.5
3 info using node@v14.4.0
4 verbose npm-session 20fd79847bfb7531
5 silly install loadCurrentTree
6 silly install readGlobalPackageData
7 silly fetchPackageMetaData error for github:DMBlakeley/homebridge-myq2 premature close
8 timing stage:rollbackFailedOptional Completed in 0ms
9 timing stage:runTopLevelLifecycles Completed in 1833ms
10 verbose stack Error: premature close
10 verbose stack     at PassThrough.onclose (/usr/local/lib/node_modules/npm/node_modules/end-of-stream/index.js:47:67)
10 verbose stack     at PassThrough.emit (events.js:327:22)
10 verbose stack     at emitCloseNT (internal/streams/destroy.js:81:10)
10 verbose stack     at processTicksAndRejections (internal/process/task_queues.js:83:21)
11 verbose cwd /Users/maxj/dev/github/CuraEngine/build
12 verbose Darwin 19.5.0
13 verbose argv "/usr/local/Cellar/node/14.4.0/bin/node" "/usr/local/bin/npm" "install" "-g" "DMBlakeley/homebridge-myq2"
14 verbose node v14.4.0
15 verbose npm  v6.14.5
16 error premature close
17 verbose exit [ 1, true ]`